### PR TITLE
Update Algorithm Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # LSODA.jl
 
-## Introduction 
+## Introduction
 
 **LSODA.jl** is a Julia package that interfaces to the [liblsoda](https://github.com/sdwfrost/liblsoda) library, developed by [Simon Frost](http://www.vet.cam.ac.uk/directory/sdf22@cam.ac.uk) ([@sdwfrost](http://github.com/sdwfrost)), thereby providing a way to use the LSODA algorithm from Linda Petzold and Alan Hindmarsh from [Julia](http://julialang.org/). **[Clang.jl](https://github.com/ihnorton/Clang.jl)** has been used to write the library and **[Sundials.jl](https://github.com/JuliaDiffEq/Sundials.jl)** was a inspiring source.
 
@@ -75,10 +75,10 @@ tspan = (0., 0.4)
 prob = ODEProblem(rhs!,y0,tspan)
 ```
 
-This problem is solved by LSODA by using the LSODAAlg() algorithm in the common `solve` command as follows:
+This problem is solved by LSODA by using the lsoda() algorithm in the common `solve` command as follows:
 
 ```
-sol = solve(prob,LSODAAlg())
+sol = solve(prob,lsoda())
 ```
 
 Many keyword arguments can be used to control the solver, its tolerances, and its output formats. For more information, please see the [DifferentialEquations.jl documentation](https://juliadiffeq.github.io/DiffEqDocs.jl/latest/).

--- a/src/LSODA.jl
+++ b/src/LSODA.jl
@@ -3,6 +3,9 @@ module LSODA
 using Compat, DiffEqBase
 import DiffEqBase: solve
 
+abstract LSODAAlgorithm <: AbstractODEAlgorithm
+immutable lsoda <: LSODAAlgorithm end
+
 const depsfile = joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl")
 if isfile(depsfile)
     include(depsfile)
@@ -12,7 +15,7 @@ end
 
 export lsoda, lsoda_0, lsoda_opt_t, lsoda_context_t, lsoda_prepare, lsoda_opt_t, lsoda_free, lsoda_evolve!, UserFunctionAndData
 
-export LSODAAlgorithm, LSODAAlg, solve
+export LSODAAlgorithm, solve
 
 include("types_and_consts.jl")
 include("solver.jl")

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,6 +1,3 @@
-abstract LSODAAlgorithm <: AbstractODEAlgorithm
-immutable LSODAAlg <: LSODAAlgorithm end
-
 ## Common Interface Solve Functions
 
 function solve{uType,tType,isinplace,F}(

--- a/test/test_common.jl
+++ b/test/test_common.jl
@@ -1,10 +1,10 @@
 using LSODA, DiffEqProblemLibrary
 prob = prob_ode_linear
-sol = solve(prob,LSODAAlg(),save_timeseries=false,saveat=[1/2])
+sol = solve(prob,lsoda(),save_timeseries=false,saveat=[1/2])
 prob = prob_ode_2Dlinear
-sol = solve(prob,LSODAAlg(),save_timeseries=false,saveat=[1/2])
+sol = solve(prob,lsoda(),save_timeseries=false,saveat=[1/2])
 
 prob = prob_ode_linear
-sol = solve(prob,LSODAAlg(),save_timeseries=true,saveat=[1/2])
+sol = solve(prob,lsoda(),save_timeseries=true,saveat=[1/2])
 prob = prob_ode_2Dlinear
-sol = solve(prob,LSODAAlg(),save_timeseries=true,saveat=[1/2])
+sol = solve(prob,lsoda(),save_timeseries=true,saveat=[1/2])


### PR DESCRIPTION
By setting the type-declaration before the function declaration, I was able to make `lsoda()` be the algorithm name for the common interface. Now it looks like 

```julia
sol = solve(prob,lsoda())
```

which I thnk looks much nicer. The README was updated to reflect this.