### PR TITLE
use compat on the abstract type

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5
 BinDeps 0.4.3
-Compat 0.9.0
+Compat 0.17.0
 Parameters 0.5.0
 DiffEqBase 0.15.0

--- a/src/LSODA.jl
+++ b/src/LSODA.jl
@@ -5,7 +5,7 @@ module LSODA
 using Compat, DiffEqBase
 import DiffEqBase: solve
 
-abstract LSODAAlgorithm <: AbstractODEAlgorithm
+@compat abstract type LSODAAlgorithm <: AbstractODEAlgorithm end
 immutable lsoda <: LSODAAlgorithm end
 
 const depsfile = joinpath(dirname(dirname(@__FILE__)),"deps","deps.jl")


### PR DESCRIPTION
This will get rid of warnings on v0.6