### PR TITLE
Error on mass matrices

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -16,6 +16,10 @@ function solve{uType,tType,isinplace}(
         warn("save_timeseries is deprecated. Use save_everystep instead")
         _save_everystep = save_timeseries
     end
+    
+    if prob.mass_matrix != I
+        error("This solver is not able to use mass matrices.")
+    end
 
     tspan = prob.tspan
     t0 = tspan[1]


### PR DESCRIPTION
This solver cannot handle mass matrices, so it would be better to tell the user that the requested problem could not be solved if a mass matrix is set. This will require the next DiffEqBase.jl tag.