### PR TITLE
Add checks for passing explicit t-gradient or Jacobian to stiff solver

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.5
 BinDeps 0.4.3
 Compat 0.17.0
 Parameters 0.5.0
-DiffEqBase 0.15.0
+DiffEqBase 1.5.1

--- a/src/common.jl
+++ b/src/common.jl
@@ -18,18 +18,18 @@ function solve{uType,tType,isinplace}(
     kwargs...)
 
     if verbose
-        warned = false
-        isempty(kwargs) || check_keywords(alg, kwargs, warnlist)
-        if has_tgrad(prob.f)
-            warn("Explicit t-gradient given to this stiff solver is ignored.")
-            warned = true
+        warned = !isempty(kwargs) && check_keywords(alg, kwargs, warnlist)
+        if !(typeof(prob.f) <: AbstractParameterizedFunction)
+            if has_tgrad(prob.f)
+                warn("Explicit t-gradient given to this stiff solver is ignored.")
+                warned = true
+            end
+            if has_jac(prob.f)
+                warn("Explicit Jacobian given to this stiff solver is ignored.")
+                warned = true
+            end
         end
-        if has_jac(prob.f)
-            warn("Explicit Jacobian given to this stiff solver is ignored.")
-            warned = true
-        end
-        warned &&
-            warn("See http://docs.juliadiffeq.org/latest/basics/compatibility_chart.html")
+        warned && warn_compat()
     end
 
     if save_timeseries != nothing


### PR DESCRIPTION
Cleaned up the way of checking both keyword arguments and t-gradient & Jacobian