### PR TITLE
GC handles and finalizers for contexts

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -139,6 +139,7 @@ function solve{uType,tType,isinplace}(
     ctx.neq = neq
     ctx.state = 1
     ctx.data = pointer_from_objref(userfun)
+    ch = ContextHandle(ctx)
 
     lsoda_prepare(ctx,opt)
 
@@ -198,7 +199,7 @@ function solve{uType,tType,isinplace}(
         end
     end
 
-    lsoda_free(ctx)
+    lsoda_free(ch)
 
     build_solution(prob, alg, ts, timeseries,
                    timeseries_errors = timeseries_errors,

--- a/src/handle.jl
+++ b/src/handle.jl
@@ -1,1 +1,25 @@
+abstract type AbstractLSODAHandle end
 
+mutable struct ContextHandle <: AbstractLSODAHandle
+    ctx::lsoda_context_t
+    freed::Bool
+    function (::Type{ContextHandle})(ctx::lsoda_context_t)
+        h = new(ctx,false)
+        finalizer(h, release_handle)
+        return h
+    end
+end
+release_handle(ch::ContextHandle) = lsoda_free(ch)
+
+function lsoda_free(ch::ContextHandle)
+    if !ch.freed
+        lsoda_free(ch.ctx)
+        ch.freed = true
+    end
+    nothing
+end
+
+# Now wrap the rest of the APIs for convenience
+lsoda_reset(ch::ContextHandle) = lsoda_reset(ch.ctx)
+lsoda_prepare(ch::ContextHandle,opt::lsoda_opt_t) = lsoda_prepare(ch.ctx,opt)
+lsoda(ch::ContextHandle,y::Vector,t::Vector{Float64},tout) = lsoda(ch.ctx,y,t,tout)

--- a/src/types_and_consts.jl
+++ b/src/types_and_consts.jl
@@ -1,6 +1,6 @@
 using Parameters, Compat
 
-@with_kw type lsoda_common_t 
+@with_kw type lsoda_common_t
     yh::Ptr{Ptr{Cdouble}}= C_NULL
     wm::Ptr{Ptr{Cdouble}}= C_NULL
     ewt::Ptr{Cdouble}= C_NULL
@@ -43,7 +43,7 @@ using Parameters, Compat
     miter::Cint = 0
 end
 
-@with_kw type lsoda_opt_t 
+@with_kw type lsoda_opt_t
 	  ixpr::Cint = 0
     mxstep::Cint = 0
     mxhnil::Cint = 0
@@ -59,9 +59,7 @@ end
     atol::Ptr{Cdouble} = C_NULL
 end
 
-# typealias _lsoda_f Ptr{Void} #: it was for v0.5
 const _lsoda_f = Ptr{Void}
-
 
 @with_kw type lsoda_context_t 
     function_::_lsoda_f = C_NULL
@@ -72,7 +70,7 @@ const _lsoda_f = Ptr{Void}
     common::Ptr{lsoda_common_t} = C_NULL
     opt::Ptr{lsoda_opt_t} = C_NULL
 end
-# typealias lsoda_context_t_ptr Ptr{lsoda_context_t}# it was for v0.5
+
 const lsoda_context_t_ptr = Ptr{lsoda_context_t}
 
 type UserFunctionAndData


### PR DESCRIPTION
This allows the context object to be finalized when no references exist. This will allow for an integrator interface to be developed for LSODA.