### PR TITLE
Bump DiffEqBase / SciMLBase compat to include v7 / v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LSODA"
 uuid = "7f56f5a3-f504-529b-bc02-0b1fe5e64312"
 authors = ["Romain Veltz and Chris Rackauckas"]
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -14,9 +14,9 @@ SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 Compat = "4"
-DiffEqBase = "6"
+DiffEqBase = "6, 7"
 Parameters = "0.12"
-SciMLBase = "1.80, 2"
+SciMLBase = "1.80, 2, 3"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
## Summary

Widen compat so LSODA.jl resolves alongside the v7 OrdinaryDiffEq stack (lib/DiffEqBase 7.0.0, SciMLBase 3):

- `DiffEqBase: "6"` → `"6, 7"`
- `SciMLBase: "1.80, 2"` → `"1.80, 2, 3"`

Version bump 0.7.6 → 0.7.7.

## Why this is source-level safe

LSODA.jl's DiffEqBase / SciMLBase surface is small and entirely stable across the v7/v3 rename:

- `DiffEqBase.AbstractODEAlgorithm` (`src/LSODA.jl:19`)
- `SciMLBase.alg_order` (`src/LSODA.jl:21`)
- `DiffEqBase.__solve`, `DiffEqBase.AbstractODEProblem`, `DiffEqBase.AbstractParameterizedFunction`, `DiffEqBase.has_tgrad`, `DiffEqBase.has_jac`, `DiffEqBase.build_solution` (`src/common.jl`)

All of these remain in lib/DiffEqBase v7 and SciMLBase v3 unchanged (verified against `lib/DiffEqBase/src/DiffEqBase.jl` in SciML/OrdinaryDiffEq.jl master).

Grepped `src/` clean for every symbol removed in the v7 NEWS / SciMLBase v3 breaking notes: `u_modified!`, `has_destats`, `.destats`, `concrete_solve`, `fastpow`, `RECOMPILE_BY_DEFAULT`, `DEStats`, `QuadratureProblem`, `tuples()`/`intervals()`, standalone `DEAlgorithm`/`DEProblem`/`DESolution`. Zero matches.

## Motivation

OrdinaryDiffEq.jl is preparing a v7 release that bumps DiffEqBase to v7 and SciMLBase to v3. SciML/OrdinaryDiffEq.jl#3488 is the integration branch. LSODA.jl's current `DiffEqBase = "6"` / `SciMLBase = "1.80, 2"` cap prevents it from being installed alongside the v7 stack — `Pkg` would report `Unsatisfiable requirements detected for package LSODA`. This PR widens that cap.

## Scope

Part of the broader v7-compat-widening set for SciML downstream packages:
- SciML/DiffEqCallbacks.jl#303
- SciML/DiffEqNoiseProcess.jl#271
- SciML/DiffEqProblemLibrary.jl#182
- SciML/JumpProcesses.jl#580
- SciML/ModelingToolkit.jl#4467
- JuliaComputing/StateSelection.jl#71
- SciML/ParameterizedFunctions.jl#151
- SciML/SciMLSensitivity.jl#1431
- SciML/Sundials.jl#526
- SciML/ODEInterfaceDiffEq.jl#95
- SciML/DiffEqFinancial.jl#68
- SciML/DiffEqPhysics.jl#107
- SciML/MethodOfLines.jl#552
- SciML/Catalyst.jl#1463

## Test plan

- [x] Source grep for every removed v7/v3 symbol — clean.
- [ ] CI on this PR (against the currently-registered DiffEqBase 6.x / SciMLBase 2.x line; source unchanged; expected green).
- [ ] Once DiffEqBase 7 / SciMLBase 3 are registered, downstream users should be able to install LSODA alongside them.

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>