### PR TITLE
Bump major version (0.7.7 → 0.8.0) for SciMLBase v3 / DiffEqBase v7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LSODA"
 uuid = "7f56f5a3-f504-529b-bc02-0b1fe5e64312"
 authors = ["Romain Veltz and Chris Rackauckas"]
-version = "0.7.7"
+version = "0.8.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## Summary

The SciMLBase v3 / DiffEqBase v7 / OrdinaryDiffEq v7 release is **breaking** across the ecosystem (typed `verbose` / `DEVerbosity` instead of `Bool`, `AutoSpecialize` `ODEFunction` default, controllers as objects, RAT v4, removed re-exports, etc. — see [the OrdinaryDiffEq v7 NEWS.md](https://github.com/SciML/OrdinaryDiffEq.jl/blob/master/NEWS.md)).

`master` already widened compat to include SciMLBase v3 / DiffEqBase v7, but the latest registered version is still on the prior major. Per SemVer, that ecosystem upgrade should ride a major bump so users opt into v3 explicitly rather than getting it via a routine update.

The package source already runs against both the v2 and v3 ecosystems (compat covers both), so no code changes are needed — this is a version-only bump. Companion PRs landed for DASKR, DASSL, IRKGaussLegendre, and ODEInterfaceDiffEq, with their pre-major v3-allowing releases yanked in https://github.com/JuliaRegistries/General/pull/153846.

## Test plan
- [ ] CI green
- [ ] After merge, register with `@JuliaRegistrator register()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)